### PR TITLE
Do not display admin notice on block editor

### DIFF
--- a/includes/managers/class-fs-admin-notice-manager.php
+++ b/includes/managers/class-fs-admin-notice-manager.php
@@ -218,6 +218,13 @@
                 // Only show messages to admins.
                 return;
             }
+            // only show on screens not excluded
+	        $display_not_on = array(
+		        'post'
+	        );
+	        if ( in_array( get_current_screen()->base, apply_filters('hide_fs_notices',$display_not_on )) ) {
+		        return;
+	        }
 
             foreach ( $this->_notices as $id => $msg ) {
                 if ( isset( $msg['wp_user_id'] ) && is_numeric( $msg['wp_user_id'] ) ) {


### PR DESCRIPTION
For 5.0  admin notices interfere with the block editor. This stops notices being displayed on a filterable list of admin screens defaulted to 'posts' where the block editor lives